### PR TITLE
main: change panic message to match Linux

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn on_panic(info: &PanicInfo) -> ! {
 
     let panic_msg = info.message();
 
-    error!("Kernel Panic: {panic_msg}");
+    error!("Kernel panic - not syncing: {panic_msg}");
 
     ArchImpl::halt();
 }


### PR DESCRIPTION
It is imperative for true Linux compatibility and for all of its quirkiness, that the kernel duly notify the user on fatal error conditions within the kernel that it is most definitely NOT SYNCING.