### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ model within the kernel context:
 
 ###  Process Management
 * Full task management including scheduling and task migration via IPIs.
-* Currently implements [51 Linux syscalls](./etc/syscalls.md); sufficient to execute most BusyBox
+* Currently implements [51 Linux syscalls](./etc/syscalls_linux_aarch64.md); sufficient to execute most BusyBox
   commands.
 * Advanced forking capabilities via `clone()`.
 * Process and thread signal delivery and raising support.


### PR DESCRIPTION
I forgot to change the link when renaming the file. This PR fixes that.