### PR TITLE
Include line/col info in kernel panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,17 @@ fn on_panic(info: &PanicInfo) -> ! {
 
     let panic_msg = info.message();
 
-    error!("Kernel panic - not syncing: {panic_msg}");
+    if let Some(location) = info.location() {
+        error!(
+            "Kernel panicked at {}:{}:{}: {}",
+            location.file(),
+            location.line(),
+            location.column(),
+            panic_msg
+        );
+    } else {
+        error!("Kernel panicked at unknown location: {panic_msg}");
+    }
 
     ArchImpl::halt();
 }


### PR DESCRIPTION
To test this, try exiting bash.

Before:
```
bash-5.3# exit
exit
[    1.1448112] moss: Kernel panic: not yet implemented
```
After:
```
bash-5.3# exit
exit
[    1.1448112] moss: Kernel panicked at libkernel/src/error/syscall_error.rs:50:14: not yet implemented
```

Should help with debugging.

I was going to try to add backtrace support, but due to this being a `no_std` environment, this a little more difficult.

