### PR TITLE
arch: arm64: parse cmdline from chosen node

### DIFF
--- a/scripts/qemu-runner.sh
+++ b/scripts/qemu-runner.sh
@@ -8,4 +8,4 @@ bin="${elf%.elf}.bin"
 
 # Convert to binary format
 aarch64-none-elf-objcopy -O binary "$elf" "$bin"
-qemu-system-aarch64 -M virt,gic-version=3 -initrd moss.img -cpu cortex-a72 -m 2G -smp 4 -nographic -s -kernel "$bin"
+qemu-system-aarch64 -M virt,gic-version=3 -initrd moss.img -cpu cortex-a72 -m 2G -smp 4 -nographic -s -kernel "$bin" -append "--init=/bin/bash --rootfs=fat32fs --automount=/dev,devfs"

--- a/src/arch/arm64/boot/mod.rs
+++ b/src/arch/arm64/boot/mod.rs
@@ -21,7 +21,6 @@ use aarch64_cpu::{
     asm::{self, barrier},
     registers::{ReadWriteable, SCTLR_EL1, TCR_EL1, TTBR0_EL1},
 };
-use alloc::string::ToString;
 use core::arch::global_asm;
 use libkernel::{
     CpuOps,
@@ -125,10 +124,9 @@ fn arch_init_stage2(frame: *mut ExceptionState) -> *mut ExceptionState {
 
     cpu_messenger_init(cpu_count());
 
-    kmain(
-        "--init=/bin/bash --rootfs=fat32fs --automount=/dev,devfs".to_string(),
-        frame,
-    );
+    let cmdline = super::fdt::get_cmdline();
+
+    kmain(cmdline.unwrap_or_default(), frame);
 
     boot_secondaries();
 

--- a/src/arch/arm64/fdt.rs
+++ b/src/arch/arm64/fdt.rs
@@ -1,1 +1,10 @@
+use crate::drivers::fdt_prober::get_fdt;
+use alloc::string::{String, ToString};
+
 pub const MAX_FDT_SZ: usize = 2 * 1024 * 1024;
+
+pub fn get_cmdline() -> Option<String> {
+    let fdt = get_fdt();
+
+    Some(fdt.chosen()?.bootargs()?.to_string())
+}


### PR DESCRIPTION
The kernel command line is passed via the FDT's chosen node. Use that, rather than hard-coding it into the kernel.

Fixes: #20