### PR TITLE
Test read syscall in userspace

### DIFF
--- a/usertest/src/main.rs
+++ b/usertest/src/main.rs
@@ -76,7 +76,7 @@ fn test_read() {
     print!("Testing read syscall ...");
     let file = "/dev/zero";
     let c_file = std::ffi::CString::new(file).unwrap();
-    let mut buffer = [0u8; 16];
+    let mut buffer = [1u8; 16];
     unsafe {
         let fd = libc::open(c_file.as_ptr(), libc::O_RDONLY);
         if fd < 0 {


### PR DESCRIPTION
Now that we have `/dev/zero/` testing that read fills the buffer is trivial.