### PR TITLE
Add rust file/dir usertest

### DIFF
--- a/usertest/src/main.rs
+++ b/usertest/src/main.rs
@@ -119,12 +119,14 @@ fn test_rust_file() {
     let path = "/tmp/rust_fs_test.txt";
     {
         let mut file = File::create(path).expect("Failed to create file");
-        file.write_all(b"Hello, Rust!").expect("Failed to write to file");
+        file.write_all(b"Hello, Rust!")
+            .expect("Failed to write to file");
     }
     {
         let mut file = File::open(path).expect("Failed to open file");
         let mut contents = String::new();
-        file.read_to_string(&mut contents).expect("Failed to read from file");
+        file.read_to_string(&mut contents)
+            .expect("Failed to read from file");
         assert_eq!(contents, "Hello, Rust!");
     }
     fs::remove_file(path).expect("Failed to delete file");


### PR DESCRIPTION
Ensures rust filesystem opts work by testing on tmp fs. Provides testing for #53 and #63.