### PR TITLE
sys_set_tid_address: finish implementation

### DIFF
--- a/src/arch/arm64/exceptions/syscall.rs
+++ b/src/arch/arm64/exceptions/syscall.rs
@@ -167,7 +167,7 @@ pub async fn handle_syscall() {
         0x51 => sys_sync().await,
         0x5d => sys_exit(arg1 as _).await,
         0x5e => sys_exit_group(arg1 as _),
-        0x60 => sys_set_tid_address(VA::from_value(arg1 as _)).await,
+        0x60 => sys_set_tid_address(TUA::from_value(arg1 as _)),
         0x62 => {
             sys_futex(
                 TUA::from_value(arg1 as _),

--- a/src/process/threading/mod.rs
+++ b/src/process/threading/mod.rs
@@ -4,17 +4,17 @@ use core::mem::size_of;
 use crate::sched::current_task;
 use libkernel::{
     error::{KernelError, Result},
-    memory::address::{TUA, VA},
+    memory::address::TUA,
 };
 
 pub mod futex;
 
-pub async fn sys_set_tid_address(_tidptr: VA) -> Result<usize> {
-    let tid = current_task().tid;
+pub fn sys_set_tid_address(tidptr: TUA<u32>) -> Result<usize> {
+    let task = current_task();
 
-    // TODO: implement threading and this system call properly. For now, we just
-    // return the PID as the thread id.
-    Ok(tid.value() as _)
+    *task.child_tid_ptr.lock_save_irq() = Some(tidptr);
+
+    Ok(task.tid.value() as _)
 }
 
 #[repr(C)]


### PR DESCRIPTION
Now CLONE_CHILD_CLEARTID has been implemented properly, we can finish the implementation of `sys_set_tid_address`.