### PR TITLE
Implement proper AtFlags handling for path resolution

### DIFF
--- a/src/arch/arm64/exceptions/syscall.rs
+++ b/src/arch/arm64/exceptions/syscall.rs
@@ -114,6 +114,7 @@ pub async fn handle_syscall() {
                 TUA::from_value(arg2 as _),
                 arg3.into(),
                 TUA::from_value(arg4 as _),
+                arg5 as _,
             )
             .await
         }
@@ -124,13 +125,22 @@ pub async fn handle_syscall() {
         0x32 => sys_fchdir(arg1.into()).await,
         0x33 => sys_chroot(TUA::from_value(arg1 as _)).await,
         0x34 => sys_fchmod(arg1.into(), arg2 as _).await,
-        0x35 => sys_fchmodat(arg1.into(), TUA::from_value(arg2 as _), arg3 as _).await,
+        0x35 => {
+            sys_fchmodat(
+                arg1.into(),
+                TUA::from_value(arg2 as _),
+                arg3 as _,
+                arg4 as _,
+            )
+            .await
+        }
         0x36 => {
             sys_fchownat(
                 arg1.into(),
                 TUA::from_value(arg2 as _),
                 arg3.into(),
                 arg4.into(),
+                arg5 as _,
             )
             .await
         }
@@ -207,6 +217,7 @@ pub async fn handle_syscall() {
                 arg1.into(),
                 TUA::from_value(arg2 as _),
                 TUA::from_value(arg3 as _),
+                arg4 as _,
             )
             .await
         }

--- a/src/fs/syscalls/at/chmod.rs
+++ b/src/fs/syscalls/at/chmod.rs
@@ -1,19 +1,24 @@
 use core::ffi::c_char;
 
 use libkernel::{
-    error::Result,
+    error::{KernelError, Result},
     fs::{attr::FilePermissions, path::Path},
     memory::address::TUA,
 };
 
 use crate::{
-    fs::{VFS, syscalls::at::resolve_at_start_node},
+    fs::syscalls::at::{AtFlags, resolve_at_start_node, resolve_path_flags},
     memory::uaccess::cstr::UserCStr,
     process::fd_table::Fd,
     sched::current_task,
 };
 
-pub async fn sys_fchmodat(dirfd: Fd, path: TUA<c_char>, mode: u16) -> Result<usize> {
+pub async fn sys_fchmodat(dirfd: Fd, path: TUA<c_char>, mode: u16, flags: i32) -> Result<usize> {
+    let flags = AtFlags::from_bits_retain(flags);
+    if flags.contains(AtFlags::AT_SYMLINK_NOFOLLOW) {
+        return Err(KernelError::NotSupported); // per fchmodat(2) this is not supported
+    }
+
     let mut buf = [0; 1024];
 
     let task = current_task();
@@ -21,7 +26,7 @@ pub async fn sys_fchmodat(dirfd: Fd, path: TUA<c_char>, mode: u16) -> Result<usi
     let start_node = resolve_at_start_node(dirfd, path).await?;
     let mode = FilePermissions::from_bits_retain(mode);
 
-    let node = VFS.resolve_path(path, start_node, task).await?;
+    let node = resolve_path_flags(dirfd, path, start_node, task, flags).await?;
     let mut attr = node.getattr().await?;
 
     attr.mode = mode;

--- a/src/fs/syscalls/at/chown.rs
+++ b/src/fs/syscalls/at/chown.rs
@@ -8,20 +8,27 @@ use libkernel::{
 };
 
 use crate::{
-    fs::{VFS, syscalls::at::resolve_at_start_node},
+    fs::syscalls::at::{AtFlags, resolve_at_start_node, resolve_path_flags},
     memory::uaccess::cstr::UserCStr,
     process::fd_table::Fd,
     sched::current_task,
 };
 
-pub async fn sys_fchownat(dirfd: Fd, path: TUA<c_char>, owner: Uid, group: Gid) -> Result<usize> {
+pub async fn sys_fchownat(
+    dirfd: Fd,
+    path: TUA<c_char>,
+    owner: Uid,
+    group: Gid,
+    flags: i32,
+) -> Result<usize> {
     let mut buf = [0; 1024];
 
     let task = current_task();
     let path = Path::new(UserCStr::from_ptr(path).copy_from_user(&mut buf).await?);
     let start_node = resolve_at_start_node(dirfd, path).await?;
+    let flags = AtFlags::from_bits_retain(flags);
 
-    let node = VFS.resolve_path(path, start_node, task).await?;
+    let node = resolve_path_flags(dirfd, path, start_node, task, flags).await?;
     let mut attr = node.getattr().await?;
 
     attr.uid = owner;

--- a/src/fs/syscalls/at/link.rs
+++ b/src/fs/syscalls/at/link.rs
@@ -1,9 +1,16 @@
 use core::ffi::c_char;
 
-use libkernel::{error::Result, fs::path::Path, memory::address::TUA};
+use libkernel::{
+    error::{FsError, KernelError, Result},
+    fs::{FileType, path::Path},
+    memory::address::TUA,
+};
 
 use crate::{
-    fs::{VFS, syscalls::at::resolve_at_start_node},
+    fs::{
+        VFS,
+        syscalls::at::{AtFlags, resolve_at_start_node, resolve_path_flags},
+    },
     memory::uaccess::cstr::UserCStr,
     process::fd_table::Fd,
     sched::current_task,
@@ -14,11 +21,21 @@ pub async fn sys_linkat(
     old_path: TUA<c_char>,
     new_dirfd: Fd,
     new_path: TUA<c_char>,
+    flags: i32,
 ) -> Result<usize> {
     let mut buf = [0; 1024];
     let mut buf2 = [0; 1024];
 
     let task = current_task();
+    let mut flags = AtFlags::from_bits_retain(flags);
+
+    // following symlinks is implied for any other syscall.
+    // for linkat though, we need to specify nofollow since
+    // linkat implicitly does not follow symlinks unless specified.
+    if !flags.contains(AtFlags::AT_SYMLINK_FOLLOW) {
+        flags.insert(AtFlags::AT_SYMLINK_NOFOLLOW);
+    }
+
     let old_path = Path::new(
         UserCStr::from_ptr(old_path)
             .copy_from_user(&mut buf)
@@ -32,8 +49,47 @@ pub async fn sys_linkat(
     let old_start_node = resolve_at_start_node(old_dirfd, old_path).await?;
     let new_start_node = resolve_at_start_node(new_dirfd, new_path).await?;
 
-    VFS.link(old_path, new_path, old_start_node, new_start_node, task)
-        .await?;
+    let target_inode = resolve_path_flags(
+        old_dirfd,
+        old_path,
+        old_start_node.clone(),
+        task.clone(),
+        flags,
+    )
+    .await?;
+
+    let attr = target_inode.getattr().await?;
+
+    if attr.file_type == FileType::Directory {
+        return Err(FsError::IsADirectory.into());
+    }
+
+    // newpath does not follow flags, and doesnt follow symlinks either
+    if VFS
+        .resolve_path_nofollow(new_path, new_start_node.clone(), task.clone())
+        .await
+        .is_ok()
+    {
+        return Err(FsError::AlreadyExists.into());
+    }
+
+    // parent newpath should follow symlinks though
+    let parent_inode = if let Some(parent) = new_path.parent() {
+        VFS.resolve_path(parent, new_start_node, task).await?
+    } else {
+        new_start_node
+    };
+
+    if parent_inode.getattr().await?.file_type != FileType::Directory {
+        return Err(FsError::NotADirectory.into());
+    }
+
+    VFS.link(
+        target_inode,
+        parent_inode,
+        new_path.file_name().ok_or(KernelError::InvalidValue)?,
+    )
+    .await?;
 
     Ok(0)
 }

--- a/src/fs/syscalls/at/mod.rs
+++ b/src/fs/syscalls/at/mod.rs
@@ -1,4 +1,8 @@
-use crate::{process::fd_table::Fd, sched::current_task};
+use crate::{
+    fs::VFS,
+    process::{Task, fd_table::Fd},
+    sched::current_task,
+};
 use alloc::sync::Arc;
 use libkernel::{
     error::{FsError, KernelError, Result},
@@ -22,6 +26,7 @@ bitflags::bitflags! {
     pub struct AtFlags: i32 {
         const AT_SYMLINK_NOFOLLOW = 0x100; // Do not follow symbolic links.
         const AT_EACCESS = 0x200;          // Check effective IDs in faccessat*.
+        const AT_SYMLINK_FOLLOW = 0x400;   // Follow symbolic links.
         const AT_NO_AUTOMOUNT = 0x800;     // Suppress terminal automount traversal.
         const AT_EMPTY_PATH = 0x1000;      // Allow empty relative pathname.
     }
@@ -56,4 +61,33 @@ async fn resolve_at_start_node(dirfd: Fd, path: &Path) -> Result<Arc<dyn Inode>>
     };
 
     Ok(start_node)
+}
+
+async fn resolve_path_flags(
+    dirfd: Fd,
+    path: &Path,
+    root: Arc<dyn Inode>,
+    task: Arc<Task>,
+    flags: AtFlags,
+) -> Result<Arc<dyn Inode>> {
+    // simply return the inode that dirfd refers to
+    if flags.contains(AtFlags::AT_EMPTY_PATH) && path.as_str().is_empty() {
+        return Ok(if dirfd.is_atcwd() {
+            task.cwd.lock_save_irq().0.clone()
+        } else {
+            let file = task
+                .fd_table
+                .lock_save_irq()
+                .get(dirfd)
+                .ok_or(KernelError::BadFd)?;
+
+            file.inode().ok_or(KernelError::NotSupported)?
+        });
+    };
+
+    if flags.contains(AtFlags::AT_SYMLINK_NOFOLLOW) {
+        return VFS.resolve_path_nofollow(path, root, task).await;
+    }
+
+    VFS.resolve_path(path, root, task).await
 }


### PR DESCRIPTION
Allows AtFlags like `AT_EMPTY_PATH` and `AT_SYMLINK_NOFOLLOW` to influence how path resolution is performed for *at syscalls.