### PR TITLE
Add .lldbinit file

### DIFF
--- a/.lldbinit
+++ b/.lldbinit
@@ -1,0 +1,2 @@
+target create --arch aarch64 target/aarch64-unknown-none-softfloat/debug/moss
+gdb-remote 1234


### PR DESCRIPTION
I find it useful on macOS because I don't need to use gdb.