### PR TITLE
arm64: memory: heap: use irq-saving spinlock

### DIFF
--- a/src/arch/arm64/boot/memory.rs
+++ b/src/arch/arm64/boot/memory.rs
@@ -158,7 +158,7 @@ pub fn setup_stack_and_heap(pgtbl_base: TPA<PgTableArray<L0Table>>) -> Result<VA
     )?;
 
     unsafe {
-        HEAP_ALLOCATOR.lock().init(
+        HEAP_ALLOCATOR.0.lock_save_irq().init(
             heap_virt_region.start_address().as_ptr_mut().cast(),
             heap_virt_region.size(),
         )

--- a/src/arch/arm64/memory/mod.rs
+++ b/src/arch/arm64/memory/mod.rs
@@ -1,5 +1,12 @@
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    ptr::NonNull,
+};
+
 use libkernel::memory::address::{PA, VA};
-use linked_list_allocator::LockedHeap;
+use linked_list_allocator::Heap;
+
+use crate::sync::SpinLock;
 
 pub mod address_space;
 pub mod fault;
@@ -17,8 +24,28 @@ pub const EXCEPTION_BASE: VA = VA::from_value(0xffff_e000_0000_0000);
 const BOGUS_START: PA = PA::from_value(usize::MAX);
 static mut KIMAGE_START: PA = BOGUS_START;
 
+pub struct SpinlockHeap(pub SpinLock<Heap>);
+
 #[global_allocator]
-pub static HEAP_ALLOCATOR: LockedHeap = LockedHeap::empty();
+pub static HEAP_ALLOCATOR: SpinlockHeap = SpinlockHeap(SpinLock::new(Heap::empty()));
+
+unsafe impl GlobalAlloc for SpinlockHeap {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.0
+            .lock_save_irq()
+            .allocate_first_fit(layout)
+            .ok()
+            .map_or(core::ptr::null_mut(), |allocation| allocation.as_ptr())
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe {
+            self.0
+                .lock_save_irq()
+                .deallocate(NonNull::new_unchecked(ptr), layout)
+        }
+    }
+}
 
 #[macro_export]
 macro_rules! ksym_pa {


### PR DESCRIPTION
The `LockedHeap` type provided by `linked_list` doesn't disable
interrupts when modifying the heap. This causes allocations to
potentially deadlock when allocations occur during an ISR.

Fix this by wrapping the `Heap` in our interrupt-aware spinlock.
