### PR TITLE
futex: only access `timeout` on `_WAIT` ops

### DIFF
--- a/src/process/threading/futex/mod.rs
+++ b/src/process/threading/futex/mod.rs
@@ -80,18 +80,19 @@ pub async fn sys_futex(
     };
 
     // TODO: support bitset variants properly
-    let timeout = if timeout.is_null() {
-        None
-    } else {
-        let timeout = TimeSpec::copy_from_user(timeout).await?;
-        if matches!(cmd, FUTEX_WAIT_BITSET) {
-            Some(Duration::from(timeout) - date())
-        } else {
-            Some(Duration::from(timeout))
-        }
-    };
     match cmd {
         FUTEX_WAIT | FUTEX_WAIT_BITSET => {
+            let timeout = if timeout.is_null() {
+                None
+            } else {
+                let timeout = TimeSpec::copy_from_user(timeout).await?;
+                if matches!(cmd, FUTEX_WAIT_BITSET) {
+                    Some(Duration::from(timeout) - date())
+                } else {
+                    Some(Duration::from(timeout))
+                }
+            };
+
             // Obtain (or create) the wait-queue for this futex word.
             let slot = get_or_create_queue(key);
 


### PR DESCRIPTION
The `timeout` parameter is only used for `_WAIT` futex ops. For other
ops, the `timeout` parameter is permitted to be an undefied value. The
current implementation would then try to `copy_from_user` using the
garbage pointer and fault, causing a missed wake-up and deadlock the
calling process.

Fix this by only accessing the timeout parmeter for `_WAIT` futex ops
where the parameter's value must be valid.
