### PR TITLE
Update non-breaking dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "arm-pl011-uart"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8797e113733a36b5fa906c81aefc126d255b88dd1c10a737749aa22ec7736b6a"
+checksum = "b62040eef329ede76c8b2af149362b0fd42ec9d8c436d9eb9d47db35b71cb300"
 dependencies = [
  "bitflags",
  "safe-mmio",
@@ -63,6 +63,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "fdt-parser"
@@ -266,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "b8b28f24bd43920cd8e0bc4f9c6553e8b93221c512cb9a1014987fc89d36f830"
 dependencies = [
  "memchr",
  "rustc-std-workspace-core",
@@ -317,9 +327,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59e70c4aef1e55797c2e8fd94a4f2a973fc972cfde0e0b05f683667b0cd39dd"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
@@ -341,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
 ]
@@ -434,10 +444,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ edition = "2024"
 [dependencies]
 libkernel = { path = "libkernel" }
 aarch64-cpu = "11.1.0"
-arm-pl011-uart = { version = "0.3.1", default-features = false }
+arm-pl011-uart = { version = "0.4.0", default-features = false }
 linked_list_allocator = "0.10.5"
 tock-registers = "0.10.1"
 log = "0.4.27"
 fdt-parser = "0.4.16"
 paste = "1.0.15"
-object = { version = "0.37.1", default-features = false, features = ["core", "elf", "read_core"] }
+object = { version = "0.38.0", default-features = false, features = ["core", "elf", "read_core"] }
 async-trait = "0.1.88"
 getargs = { version = "0.5.0", default-features = false }
 ringbuf = { version = "0.4.8", default-features = false, features = ["alloc"] }

--- a/libkernel/Cargo.toml
+++ b/libkernel/Cargo.toml
@@ -9,7 +9,7 @@ thiserror = { version = "2.0.12", default-features = false }
 tock-registers = "0.10.1"
 log = "0.4.27"
 async-trait = "0.1.88"
-object = { version = "0.37.1", default-features = false, features = ["core", "elf", "read_core"] }
+object = { version = "0.38.0", default-features = false, features = ["core", "elf", "read_core"] }
 bitflags = "2.9.1"
 ringbuf = { version = "0.4.8", default-features = false, features = ["alloc"] }
 intrusive-collections = { version = "0.9.7", default-features = false }


### PR DESCRIPTION
Bumps all dependencies to latest versions except for `fdt-parser`.