### PR TITLE
Fix issue with AT_EMPTY_PATH and simplify symlink handling

### DIFF
--- a/src/fs/syscalls/at/access.rs
+++ b/src/fs/syscalls/at/access.rs
@@ -20,8 +20,8 @@ pub async fn sys_faccessat2(dirfd: Fd, path: TUA<c_char>, mode: i32, flags: i32)
     let task = current_task();
     let access_mode = AccessMode::from_bits_retain(mode);
     let path = Path::new(UserCStr::from_ptr(path).copy_from_user(&mut buf).await?);
-    let start_node = resolve_at_start_node(dirfd, path).await?;
     let at_flags = AtFlags::from_bits_retain(flags);
+    let start_node = resolve_at_start_node(dirfd, path, at_flags).await?;
     let node = resolve_path_flags(dirfd, path, start_node, task.clone(), at_flags).await?;
 
     // If mode is F_OK (value 0), the check is for the file's existence.

--- a/src/fs/syscalls/at/chmod.rs
+++ b/src/fs/syscalls/at/chmod.rs
@@ -27,7 +27,7 @@ pub async fn sys_fchmodat(dirfd: Fd, path: TUA<c_char>, mode: u16, flags: i32) -
 
     let task = current_task();
     let path = Path::new(UserCStr::from_ptr(path).copy_from_user(&mut buf).await?);
-    let start_node = resolve_at_start_node(dirfd, path).await?;
+    let start_node = resolve_at_start_node(dirfd, path, flags).await?;
     let mode = FilePermissions::from_bits_retain(mode);
 
     let node = resolve_path_flags(dirfd, path, start_node, task.clone(), flags).await?;

--- a/src/fs/syscalls/at/chown.rs
+++ b/src/fs/syscalls/at/chown.rs
@@ -27,9 +27,9 @@ pub async fn sys_fchownat(
     let mut buf = [0; 1024];
 
     let task = current_task();
-    let path = Path::new(UserCStr::from_ptr(path).copy_from_user(&mut buf).await?);
-    let start_node = resolve_at_start_node(dirfd, path).await?;
     let flags = AtFlags::from_bits_retain(flags);
+    let path = Path::new(UserCStr::from_ptr(path).copy_from_user(&mut buf).await?);
+    let start_node = resolve_at_start_node(dirfd, path, flags).await?;
 
     let node = resolve_path_flags(dirfd, path, start_node, task.clone(), flags).await?;
     let mut attr = node.getattr().await?;

--- a/src/fs/syscalls/at/link.rs
+++ b/src/fs/syscalls/at/link.rs
@@ -57,8 +57,8 @@ pub async fn sys_linkat(
             .copy_from_user(&mut buf2)
             .await?,
     );
-    let old_start_node = resolve_at_start_node(old_dirfd, old_path).await?;
-    let new_start_node = resolve_at_start_node(new_dirfd, new_path).await?;
+    let old_start_node = resolve_at_start_node(old_dirfd, old_path, flags).await?;
+    let new_start_node = resolve_at_start_node(new_dirfd, new_path, flags).await?;
 
     let target_inode = resolve_path_flags(
         old_dirfd,

--- a/src/fs/syscalls/at/mkdir.rs
+++ b/src/fs/syscalls/at/mkdir.rs
@@ -1,6 +1,6 @@
 use crate::current_task;
 use crate::fs::VFS;
-use crate::fs::syscalls::at::resolve_at_start_node;
+use crate::fs::syscalls::at::{AtFlags, resolve_at_start_node};
 use crate::memory::uaccess::cstr::UserCStr;
 use crate::process::fd_table::Fd;
 use core::ffi::c_char;
@@ -17,7 +17,7 @@ pub async fn sys_mkdirat(
 
     let task = current_task();
     let path = Path::new(UserCStr::from_ptr(path).copy_from_user(&mut buf).await?);
-    let start_node = resolve_at_start_node(dirfd, path).await?;
+    let start_node = resolve_at_start_node(dirfd, path, AtFlags::empty()).await?;
     let mode = FilePermissions::from_bits_retain(mode);
 
     VFS.mkdir(path, start_node, mode, task.clone()).await?;

--- a/src/fs/syscalls/at/open.rs
+++ b/src/fs/syscalls/at/open.rs
@@ -1,4 +1,9 @@
-use crate::{fs::VFS, memory::uaccess::cstr::UserCStr, process::fd_table::Fd, sched::current_task};
+use crate::{
+    fs::{VFS, syscalls::at::AtFlags},
+    memory::uaccess::cstr::UserCStr,
+    process::fd_table::Fd,
+    sched::current_task,
+};
 use core::ffi::c_char;
 use libkernel::{
     error::Result,
@@ -14,7 +19,7 @@ pub async fn sys_openat(dirfd: Fd, path: TUA<c_char>, flags: u32, mode: u16) -> 
     let task = current_task();
     let flags = OpenFlags::from_bits_truncate(flags);
     let path = Path::new(UserCStr::from_ptr(path).copy_from_user(&mut buf).await?);
-    let start_node = resolve_at_start_node(dirfd, path).await?;
+    let start_node = resolve_at_start_node(dirfd, path, AtFlags::empty()).await?;
     let mode = FilePermissions::from_bits_retain(mode);
 
     let file = VFS

--- a/src/fs/syscalls/at/readlink.rs
+++ b/src/fs/syscalls/at/readlink.rs
@@ -1,5 +1,8 @@
 use crate::{
-    fs::{VFS, syscalls::at::resolve_at_start_node},
+    fs::{
+        VFS,
+        syscalls::at::{AtFlags, resolve_at_start_node},
+    },
     memory::uaccess::{copy_to_user_slice, cstr::UserCStr},
     process::fd_table::Fd,
     sched::current_task,
@@ -21,7 +24,7 @@ pub async fn sys_readlinkat(dirfd: Fd, path: TUA<c_char>, buf: UA, size: usize) 
             .await?,
     );
 
-    let start = resolve_at_start_node(dirfd, path).await?;
+    let start = resolve_at_start_node(dirfd, path, AtFlags::empty()).await?;
     let name = path.file_name().ok_or(FsError::InvalidInput)?;
 
     let parent = if let Some(p) = path.parent() {

--- a/src/fs/syscalls/at/rename.rs
+++ b/src/fs/syscalls/at/rename.rs
@@ -8,7 +8,10 @@ use libkernel::{
 };
 
 use crate::{
-    fs::{VFS, syscalls::at::resolve_at_start_node},
+    fs::{
+        VFS,
+        syscalls::at::{AtFlags, resolve_at_start_node},
+    },
     memory::uaccess::cstr::UserCStr,
     process::fd_table::Fd,
     sched::current_task,
@@ -64,8 +67,8 @@ pub async fn sys_renameat2(
     let old_name = old_path.file_name().ok_or(FsError::InvalidInput)?;
     let new_name = new_path.file_name().ok_or(FsError::InvalidInput)?;
 
-    let old_start_node = resolve_at_start_node(old_dirfd, old_path).await?;
-    let new_start_node = resolve_at_start_node(new_dirfd, new_path).await?;
+    let old_start_node = resolve_at_start_node(old_dirfd, old_path, AtFlags::empty()).await?;
+    let new_start_node = resolve_at_start_node(new_dirfd, new_path, AtFlags::empty()).await?;
 
     let old_parent_inode = if let Some(parent_path) = old_path.parent() {
         VFS.resolve_path(parent_path, old_start_node.clone(), task.clone())

--- a/src/fs/syscalls/at/statx.rs
+++ b/src/fs/syscalls/at/statx.rs
@@ -129,7 +129,7 @@ pub async fn sys_statx(
     let mask = StatXMask::from_bits_truncate(mask);
     let path = Path::new(UserCStr::from_ptr(path).copy_from_user(&mut buf).await?);
 
-    let start_node = resolve_at_start_node(dirfd, path).await?;
+    let start_node = resolve_at_start_node(dirfd, path, flags).await?;
     let node = resolve_path_flags(dirfd, path, start_node, task.clone(), flags).await?;
 
     let attr = node.getattr().await?;

--- a/src/fs/syscalls/at/symlink.rs
+++ b/src/fs/syscalls/at/symlink.rs
@@ -3,7 +3,10 @@ use core::ffi::c_char;
 use libkernel::{error::Result, fs::path::Path, memory::address::TUA};
 
 use crate::{
-    fs::{VFS, syscalls::at::resolve_at_start_node},
+    fs::{
+        VFS,
+        syscalls::at::{AtFlags, resolve_at_start_node},
+    },
     memory::uaccess::cstr::UserCStr,
     process::fd_table::Fd,
     sched::current_task,
@@ -28,7 +31,7 @@ pub async fn sys_symlinkat(
             .copy_from_user(&mut buf2)
             .await?,
     );
-    let start_node = resolve_at_start_node(new_dirfd, target).await?;
+    let start_node = resolve_at_start_node(new_dirfd, target, AtFlags::empty()).await?;
 
     VFS.symlink(source, target, start_node, task).await?;
 

--- a/src/fs/syscalls/at/utime.rs
+++ b/src/fs/syscalls/at/utime.rs
@@ -42,8 +42,8 @@ pub async fn sys_utimensat(
         let mut buf = [0; 1024];
 
         let path = Path::new(UserCStr::from_ptr(path).copy_from_user(&mut buf).await?);
-        let start_node = resolve_at_start_node(dirfd, path).await?;
         let flags = AtFlags::from_bits_retain(flags);
+        let start_node = resolve_at_start_node(dirfd, path, flags).await?;
 
         resolve_path_flags(dirfd, path, start_node, task.clone(), flags).await?
     };


### PR DESCRIPTION
Resolves an issue with `AT_EMPTY_PATH` where `resolve_at_start_node` would attempt to resolve `dirfd` and `Path` to a start node, even if `Path` is empty and `dirfd` leads to a file, which leads to `KernelError::NotADirectory` or `KernelError::NotSupported` being returned. When `AT_EMPTY_PATH` is in flags, `resolve_at_start_node` will simply return a dummy inode. Also simplifies symlink handling in `resolve_path_internal`.