### PR TITLE
Support stat in procfs

### DIFF
--- a/src/process/thread_group.rs
+++ b/src/process/thread_group.rs
@@ -5,6 +5,7 @@ use alloc::{
     sync::{Arc, Weak},
 };
 use builder::ThreadGroupBuilder;
+use core::sync::atomic::AtomicU64;
 use core::{
     fmt::Display,
     sync::atomic::{AtomicU32, Ordering},
@@ -99,6 +100,8 @@ pub struct ThreadGroup {
     pub rsrc_lim: Arc<SpinLock<ResourceLimits>>,
     pub pending_signals: SpinLock<SigSet>,
     pub child_notifiers: ChildNotifiers,
+    pub utime: AtomicU64,
+    pub stime: AtomicU64,
     next_tid: AtomicU32,
 }
 

--- a/src/process/thread_group/builder.rs
+++ b/src/process/thread_group/builder.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::AtomicU32;
+use core::sync::atomic::{AtomicU32, AtomicU64};
 
 use alloc::{collections::btree_map::BTreeMap, sync::Arc};
 
@@ -68,6 +68,8 @@ impl ThreadGroupBuilder {
                 .unwrap_or_else(|| Arc::new(SpinLock::new(ResourceLimits::default()))),
             pending_signals: SpinLock::new(SigSet::empty()),
             child_notifiers: ChildNotifiers::new(),
+            utime: AtomicU64::new(0),
+            stime: AtomicU64::new(0),
             // Don't start from '0'. Since clone expects the parent to return
             // the tid and the child to return '0', if we started from '0' we
             // couldn't then differentiate between a child and a parent.


### PR DESCRIPTION
This allows `ps` to work. Also fixes a deadlock that was introduced in the scheduling refactor.