### PR TITLE
process: task_group: implement pg priority

### DIFF
--- a/src/drivers/fs/proc.rs
+++ b/src/drivers/fs/proc.rs
@@ -361,7 +361,7 @@ Threads:\t{tasks}\n",
                     output.push_str(&format!("{} ", task.process.stime.load(Ordering::Relaxed))); // stime
                     output.push_str(&format!("{} ", 0)); // cutime
                     output.push_str(&format!("{} ", 0)); // cstime
-                    output.push_str(&format!("{} ", task.priority)); // priority
+                    output.push_str(&format!("{} ", *task.process.priority.lock_save_irq())); // priority
                     output.push_str(&format!("{} ", 0)); // nice
                     output.push_str(&format!("{} ", 0)); // num_threads
                     output.push_str(&format!("{} ", 0)); // itrealvalue

--- a/src/process/thread_group.rs
+++ b/src/process/thread_group.rs
@@ -99,6 +99,7 @@ pub struct ThreadGroup {
     pub signals: Arc<SpinLock<SignalState>>,
     pub rsrc_lim: Arc<SpinLock<ResourceLimits>>,
     pub pending_signals: SpinLock<SigSet>,
+    pub priority: SpinLock<i8>,
     pub child_notifiers: ChildNotifiers,
     pub utime: AtomicU64,
     pub stime: AtomicU64,

--- a/src/process/thread_group/builder.rs
+++ b/src/process/thread_group/builder.rs
@@ -16,6 +16,7 @@ pub struct ThreadGroupBuilder {
     tgid: Tgid,
     parent: Option<Arc<ThreadGroup>>,
     umask: Option<u32>,
+    pri: Option<i8>,
     sigstate: Option<Arc<SpinLock<SignalState>>>,
     rsrc_lim: Option<Arc<SpinLock<ResourceLimits>>>,
 }
@@ -29,6 +30,7 @@ impl ThreadGroupBuilder {
             umask: None,
             sigstate: None,
             rsrc_lim: None,
+            pri: None,
         }
     }
 
@@ -46,6 +48,11 @@ impl ThreadGroupBuilder {
 
     pub fn with_rsrc_lim(mut self, rsrc_lim: Arc<SpinLock<ResourceLimits>>) -> Self {
         self.rsrc_lim = Some(rsrc_lim);
+        self
+    }
+
+    pub fn with_priority(mut self, priority: i8) -> Self {
+        self.pri = Some(priority);
         self
     }
 
@@ -68,6 +75,7 @@ impl ThreadGroupBuilder {
                 .unwrap_or_else(|| Arc::new(SpinLock::new(ResourceLimits::default()))),
             pending_signals: SpinLock::new(SigSet::empty()),
             child_notifiers: ChildNotifiers::new(),
+            priority: SpinLock::new(self.pri.unwrap_or(0)),
             utime: AtomicU64::new(0),
             stime: AtomicU64::new(0),
             // Don't start from '0'. Since clone expects the parent to return

--- a/src/sched/sched_task.rs
+++ b/src/sched/sched_task.rs
@@ -95,7 +95,7 @@ impl SchedulableTask {
     /// weight = priority + SCHED_WEIGHT_BASE
     /// The sum is clamped to a minimum of 1
     pub fn weight(&self) -> u32 {
-        let w = self.task.priority as i32 + SCHED_WEIGHT_BASE;
+        let w = self.priority() as i32 + SCHED_WEIGHT_BASE;
         if w <= 0 { 1 } else { w as u32 }
     }
 


### PR DESCRIPTION
Currently, each task implements it's own priority value. In Linux, each
thread group (process) has a default process which all tasks in that
group inherit. Tasks can, however, override the default process
priority.

Implement that logic here which also fixes the current compilation error
on master.
