### PR TITLE
Run CI tests to completion even if one fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         smp-feature: [ "", "smp" ]
 


### PR DESCRIPTION
Sometimes there is a spurious failure, so this helps reduce rerunning due to cancellation.