### PR TITLE
syscalls: sys_setfs{uid,gid}: implement

### DIFF
--- a/src/arch/arm64/exceptions/syscall.rs
+++ b/src/arch/arm64/exceptions/syscall.rs
@@ -44,7 +44,7 @@ use crate::{
         clone::sys_clone,
         creds::{
             sys_getegid, sys_geteuid, sys_getgid, sys_getresgid, sys_getresuid, sys_gettid,
-            sys_getuid,
+            sys_getuid, sys_setfsgid, sys_setfsuid,
         },
         exec::sys_execve,
         exit::{sys_exit, sys_exit_group},
@@ -339,6 +339,8 @@ pub async fn handle_syscall() {
             )
             .await
         }
+        0x97 => sys_setfsuid(arg1 as _).map_err(|e| match e {}),
+        0x98 => sys_setfsgid(arg1 as _).map_err(|e| match e {}),
         0x9a => sys_setpgid(arg1 as _, Pgid(arg2 as _)),
         0x9b => sys_getpgid(arg1 as _),
         0xa0 => sys_uname(TUA::from_value(arg1 as _)).await,

--- a/src/process/creds.rs
+++ b/src/process/creds.rs
@@ -93,6 +93,16 @@ pub fn sys_getegid() -> core::result::Result<usize, Infallible> {
     Ok(gid as _)
 }
 
+pub fn sys_setfsuid(_new_id: usize) -> core::result::Result<usize, Infallible> {
+    // Return the uid.  This syscall is deprecated.
+    sys_getuid()
+}
+
+pub fn sys_setfsgid(_new_id: usize) -> core::result::Result<usize, Infallible> {
+    // Return the gid. This syscall is deprecated.
+    sys_getgid()
+}
+
 pub fn sys_gettid() -> core::result::Result<usize, Infallible> {
     let tid: u32 = current_task().tid.0;
 


### PR DESCRIPTION
Implement deprecated syscalls sys_setfs{uid,gid}. We simply return the
euid and egid in this case.
