### PR TITLE
Proper timeofday implementations

### DIFF
--- a/src/arch/arm64/exceptions/syscall.rs
+++ b/src/arch/arm64/exceptions/syscall.rs
@@ -1,6 +1,9 @@
 use crate::{
     arch::{Arch, ArchImpl},
-    clock::{gettime::sys_clock_gettime, timeofday::sys_gettimeofday},
+    clock::{
+        gettime::sys_clock_gettime,
+        timeofday::{sys_gettimeofday, sys_settimeofday},
+    },
     fs::{
         dir::sys_getdents64,
         pipe::sys_pipe2,
@@ -390,6 +393,7 @@ pub async fn handle_syscall() {
         0xa6 => sys_umask(arg1 as _).map_err(|e| match e {}),
         0xa7 => sys_prctl(arg1 as _, arg2).await,
         0xa9 => sys_gettimeofday(TUA::from_value(arg1 as _), TUA::from_value(arg2 as _)).await,
+        0xaa => sys_settimeofday(TUA::from_value(arg1 as _), TUA::from_value(arg2 as _)).await,
         0xac => sys_getpid().map_err(|e| match e {}),
         0xad => sys_getppid().map_err(|e| match e {}),
         0xae => sys_getuid().map_err(|e| match e {}),

--- a/src/clock/realtime.rs
+++ b/src/clock/realtime.rs
@@ -18,5 +18,12 @@ pub fn date() -> Duration {
     }
 }
 
+pub fn set_date(duration: Duration) {
+    if let Some(now) = now() {
+        let mut epoch_info = EPOCH_DURATION.lock_save_irq();
+        *epoch_info = Some((duration, now));
+    }
+}
+
 // Represents a known duration since the epoch at the assoicated instant.
 static EPOCH_DURATION: SpinLock<Option<(Duration, Instant)>> = SpinLock::new(None);


### PR DESCRIPTION
Finishes the stub implementation of `get_timeofday` and implements `set_timeofday`. However `set_timeofday` does not handle timezone and `get_timeofday` also ignores it.