### PR TITLE
Fix mem fault crash

### DIFF
--- a/src/arch/arm64/memory/fault.rs
+++ b/src/arch/arm64/memory/fault.rs
@@ -120,12 +120,15 @@ pub fn handle_mem_fault(exception: Exception, info: AbortIss) {
     match run_mem_fault_handler(exception, info) {
         Ok(FaultResolution::Resolved) => {}
         // TODO: Implement proc signals.
-        Ok(FaultResolution::Denied) => panic!(
-            "SIGSEGV on process {} {:?} PC: {:x}",
-            current_task().process.tgid,
-            exception,
-            current_task().ctx.user().elr_el1
-        ),
+        Ok(FaultResolution::Denied) => {
+            let task = current_task();
+            panic!(
+                "SIGSEGV on process {} {:?} PC: {:x}",
+                task.process.tgid,
+                exception,
+                task.ctx.user().elr_el1
+            )
+        }
         // If the page fault involves sleepy kernel work, we can
         // spawn that work on the process, since there is no other
         // kernel work happening.


### PR DESCRIPTION
Found while debugging #128. This was masking a `SIGSEGV`.