### PR TITLE
ptrace: trace children on fork

### DIFF
--- a/src/sched/uspc_ret.rs
+++ b/src/sched/uspc_ret.rs
@@ -251,7 +251,7 @@ pub fn dispatch_userspace_task(ctx: *mut UserCtx) {
                     while let Some(signal) = task.take_signal() {
                         let mut ptrace = task.ptrace.lock_save_irq();
                         if ptrace.trace_signal(signal, task.ctx.user()) {
-                            ptrace.notify_parent_of_trap(task.process.clone());
+                            ptrace.notify_tracer_of_trap(&task.process);
                             ptrace.set_waker(create_waker(task.descriptor()));
 
                             *task.state.lock_save_irq() = TaskState::Stopped;


### PR DESCRIPTION
When calling `clone()` with PTRACE_O_TRACEFORK set, make the child
inherit the current ptrace context.  Also start the process with SIGSTOP
pending as per the ptrace docs.

This enable strace follow-forks functionality `strace -f`.

example output from `strace -f /bin/bash`:

```
clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD./strace: Process 5 attached
, child_tidptr=0x7fffff7f70f0) = 5
[pid     5] --- stopped by SIGSTOP ---
[pid     4] rt_sigprocmask(SIG_SETMASK, [INT TERM CHLD] <unfinished ...>
[pid     5] set_robust_list(0x7fffff7f7100, 24 <unfinished ...>
[pid     4] <... rt_sigprocmask resumed>, NULL, 8) = 0
[pid     5] <... set_robust_list resumed>) = 0
[pid     4] rt_sigaction(SIGTERM, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=0} <unfinished ...>
[pid     5] rt_sigprocmask(SIG_SETMASK, [INT TERM CHLD] <unfinished ...>
[pid     4] <... rt_sigaction resumed>, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, 8) = 0
[pid     5] <... rt_sigprocmask resumed>, NULL, 8) = 0
[pid     4] rt_sigprocmask(SIG_SETMASK, [] <unfinished ...>
[pid     5] getpid( <unfinished ...>
[pid     4] <... rt_sigprocmask resumed>, NULL, 8) = 0
[pid     5] <... getpid resumed>)       = 5
[pid     5] rt_sigprocmask(SIG_SETMASK, [] <unfinished ...>
[pid     4] rt_sigprocmask(SIG_BLOCK, [CHLD] <unfinished ...>
[pid     5] <... rt_sigprocmask resumed>, NULL, 8) = 0
[pid     4] <... rt_sigprocmask resumed>, [], 8) = 0
[pid     5] rt_sigaction(SIGTSTP, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0} <unfinished ...>
[pid     4] rt_sigprocmask(SIG_SETMASK, [] <unfinished ...>
[pid     5] <... rt_sigaction resumed>, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=0}, 8) = 0
[pid     4] <... rt_sigprocmask resumed>, NULL, 8) = 0
[pid     5] rt_sigaction(SIGTTIN, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0} <unfinished ...>
[pid     4] rt_sigprocmask(SIG_BLOCK, [CHLD] <unfinished ...>
[pid     5] <... rt_sigaction resumed>, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=0}, 8) = 0
[pid     4] <... rt_sigprocmask resumed>, [], 8) = 0
[pid     5] rt_sigaction(SIGTTOU, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0} <unfinished ...>
[pid     4] rt_sigaction(SIGINT, {sa_handler=0x50000005faac, sa_mask=[], sa_flags=0} <unfinished ...>
[pid     5] <... rt_sigaction resumed>, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=0}, 8) = 0
[pid     4] <... rt_sigaction resumed>, {sa_handler=0x50000008bcc0, sa_mask=[], sa_flags=0}, 8) = 0
[pid     5] rt_sigaction(SIGHUP, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, NULL, 8) = 0
[pid     4] wait4(-1 <unfinished ...>
[pid     5] rt_sigaction(SIGILL, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, NULL, 8) = 0
[pid     5] rt_sigaction(SIGTRAP, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, NULL, 8) = 0
[pid     5] rt_sigprocmask(SIG_BLOCK, ~[], [], 8) = 0
[pid     5] rt_sigaction(SIGABRT, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=0}, NULL, 8) = 0
[pid     5] rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
```
