### PR TITLE
Fix intermittent CI

### DIFF
--- a/scripts/deps/bash
+++ b/scripts/deps/bash
@@ -9,7 +9,7 @@ CC="${CC:-aarch64-linux-$stdlib-gcc}"
 pushd "build" &>/dev/null || exit 1
 
 if [ ! -d "bash-5.3" ]; then
-    wget https://ftp.gnu.org/gnu/bash/bash-5.3.tar.gz
+    wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 10 https://ftp.gnu.org/gnu/bash/bash-5.3.tar.gz
     tar xzf bash-5.3.tar.gz
 fi
 


### PR DESCRIPTION
CI sometimes fails because ftp.gnu.org likes to intermittently act as if it is offline: https://github.com/hexagonal-sun/moss-kernel/actions/runs/20759872536/job/59611693748. This adds a linear-backoff retry to that wget call.