### PR TITLE
clock_nanosleep: fix arguments to syscall

### DIFF
--- a/src/arch/arm64/exceptions/syscall.rs
+++ b/src/arch/arm64/exceptions/syscall.rs
@@ -406,8 +406,9 @@ pub async fn handle_syscall() {
         0x73 => {
             sys_clock_nanosleep(
                 arg1 as _,
-                TUA::from_value(arg2 as _),
+                arg2 as _,
                 TUA::from_value(arg3 as _),
+                TUA::from_value(arg4 as _),
             )
             .await
         }

--- a/src/process/sleep.rs
+++ b/src/process/sleep.rs
@@ -28,6 +28,7 @@ pub async fn sys_nanosleep(rqtp: TUA<TimeSpec>, rmtp: TUA<TimeSpec>) -> Result<u
 
 pub async fn sys_clock_nanosleep(
     _clock_id: i32,
+    _flags: u32,
     rqtp: TUA<TimeSpec>,
     rmtp: TUA<TimeSpec>,
 ) -> Result<usize> {


### PR DESCRIPTION
The `sys_clock_nanosleep` implementation was missing a `flags` parameter
in the second position.  This meant that `rqtp` was interpreted as
`rmtp`, and when interrupted, `rmtp` would write to a garbage address
causing an `EFAULT`.

Fix the argument ordering.
