### PR TITLE
usertest: fix test output

### DIFF
--- a/usertest/src/main.rs
+++ b/usertest/src/main.rs
@@ -1,4 +1,5 @@
 use std::{
+    io::{Write, stdout},
     sync::{Arc, Barrier, Mutex},
     thread,
 };
@@ -224,6 +225,7 @@ fn main() {
     let start = std::time::Instant::now();
     for test in inventory::iter::<Test> {
         print!("{} ...", test.test_text);
+        stdout().flush();
         run_test(test.test_fn);
         println!(" OK");
     }

--- a/usertest/src/signals.rs
+++ b/usertest/src/signals.rs
@@ -28,8 +28,6 @@ fn register_handler(signum: libc::c_int, restart: bool) {
 }
 
 fn test_interruptible_nanosleep() {
-    print!("Testing interruptible nanosleep (EINTR) ...");
-
     register_handler(libc::SIGALRM, false);
 
     unsafe {
@@ -72,7 +70,6 @@ fn test_interruptible_nanosleep() {
         // The remaining time should be updated (approx 4 seconds left)
         assert!(rem.tv_sec >= 3 && rem.tv_sec <= 5);
     }
-    println!(" OK");
 }
 
 register_test!(
@@ -81,8 +78,6 @@ register_test!(
 );
 
 fn test_interruptible_read_pipe() {
-    print!("Testing interruptible read (pipe) ...");
-
     register_handler(libc::SIGALRM, false);
 
     unsafe {
@@ -117,7 +112,6 @@ fn test_interruptible_read_pipe() {
         assert_eq!(err.raw_os_error(), Some(libc::EINTR));
         assert!(SIGNAL_CAUGHT.load(Ordering::SeqCst));
     }
-    println!(" OK");
 }
 
 register_test!(
@@ -126,8 +120,6 @@ register_test!(
 );
 
 fn test_interruptible_waitpid() {
-    print!("Testing interruptible waitpid ...");
-
     register_handler(libc::SIGALRM, false);
 
     unsafe {
@@ -168,7 +160,6 @@ fn test_interruptible_waitpid() {
             );
         }
     }
-    println!(" OK");
 }
 
 register_test!(test_interruptible_waitpid, "Testing interruptible waitpid");


### PR DESCRIPTION
Since the test driver now outputs the test name, remove test name
printing in the signal tests.

Also flush stdout when the test has began running so if a problem
occures it's easier to know which test was running.
