### PR TITLE
procfs: implement /proc/<PID>/maps

### DIFF
--- a/libkernel/src/memory/proc_vm/memory_map/mod.rs
+++ b/libkernel/src/memory/proc_vm/memory_map/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         region::VirtMemoryRegion,
     },
 };
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
 const MMAP_BASE: usize = 0x4000_0000_0000;
 
@@ -85,6 +85,7 @@ impl<AS: UserAddressSpace> MemoryMap<AS> {
         mut len: usize,
         perms: VMAPermissions,
         kind: VMAreaKind,
+        name: String,
     ) -> Result<VA> {
         if len == 0 {
             return Err(KernelError::InvalidValue);
@@ -133,7 +134,9 @@ impl<AS: UserAddressSpace> MemoryMap<AS> {
 
         // At this point, `start_addr` points to a valid, free region.
         // We can now create and insert the new VMA, handling merges.
-        let new_vma = VMArea::new(region, kind, perms);
+        let mut new_vma = VMArea::new(region, kind, perms);
+
+        new_vma.set_name(name);
 
         self.insert_and_merge(new_vma);
 
@@ -501,6 +504,10 @@ impl<AS: UserAddressSpace> MemoryMap<AS> {
 
     pub fn vma_count(&self) -> usize {
         self.vmas.len()
+    }
+
+    pub fn iter_vmas(&self) -> impl Iterator<Item = &VMArea> {
+        self.vmas.values()
     }
 }
 

--- a/libkernel/src/memory/proc_vm/memory_map/tests.rs
+++ b/libkernel/src/memory/proc_vm/memory_map/tests.rs
@@ -194,6 +194,7 @@ fn test_mmap_any_empty() {
             size,
             VMAPermissions::rw(),
             VMAreaKind::Anon,
+            String::new(),
         )
         .unwrap();
 
@@ -218,6 +219,7 @@ fn test_mmap_any_with_existing() {
             size,
             VMAPermissions::ro(),
             VMAreaKind::Anon,
+            String::new(),
         )
         .unwrap();
 
@@ -231,6 +233,7 @@ fn test_mmap_any_with_existing() {
             size,
             VMAPermissions::ro(), // different permissions to prevent merge.
             VMAreaKind::Anon,
+            String::new(),
         )
         .unwrap();
     assert_eq!(bottom_addr.value(), existing_addr - size);
@@ -254,6 +257,7 @@ fn test_mmap_hint_free() {
             size,
             VMAPermissions::rw(),
             VMAreaKind::Anon,
+            String::new(),
         )
         .unwrap();
 
@@ -282,6 +286,7 @@ fn test_mmap_hint_taken() {
             size,
             VMAPermissions::rw(),
             VMAreaKind::Anon,
+            String::new(),
         )
         .unwrap();
 
@@ -309,6 +314,7 @@ fn test_mmap_fixed_clobber_complete_overlap() {
             3 * PAGE_SIZE,
             VMAPermissions::rw(),
             VMAreaKind::Anon,
+            String::new(),
         )
         .unwrap();
 
@@ -345,6 +351,7 @@ fn test_mmap_fixed_clobber_partial_end() {
         new_size,
         VMAPermissions::rw(),
         VMAreaKind::Anon,
+        String::new(),
     )
     .unwrap();
 
@@ -378,6 +385,7 @@ fn test_mmap_fixed_clobber_partial_end_spill() {
         new_size,
         VMAPermissions::rw(),
         VMAreaKind::Anon,
+        String::new(),
     )
     .unwrap();
 
@@ -413,6 +421,7 @@ fn test_mmap_fixed_no_clobber_fails() {
             new_size,
             VMAPermissions::rw(),
             VMAreaKind::Anon,
+            String::new(),
         )
         .is_err()
     );
@@ -438,6 +447,7 @@ fn test_mmap_fixed_clobber_punch_hole() {
         new_size,
         VMAPermissions::ro(),
         VMAreaKind::Anon,
+        String::new(),
     )
     .unwrap();
 

--- a/libkernel/src/memory/proc_vm/mod.rs
+++ b/libkernel/src/memory/proc_vm/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     UserAddressSpace,
     error::{KernelError, Result},
 };
+use alloc::string::ToString;
 use memory_map::{AddressRequest, MemoryMap};
 use vmarea::{AccessKind, FaultValidation, VMAPermissions, VMArea, VMAreaKind};
 
@@ -137,6 +138,7 @@ impl<AS: UserAddressSpace> ProcessVM<AS> {
                 growth_size,
                 BRK_PERMISSIONS,
                 VMAreaKind::Anon,
+                "[heap]".to_string(),
             )?;
 
             self.brk = new_brk_region;
@@ -174,6 +176,7 @@ mod tests {
             region: VirtMemoryRegion::new(VA::from_value(0x1000), PAGE_SIZE),
             kind: VMAreaKind::Anon, // Simplification for test
             permissions: VMAPermissions::rx(),
+            name: String::new(),
         };
 
         ProcessVM::from_vma(text_vma).unwrap()
@@ -329,6 +332,7 @@ mod tests {
             region: VirtMemoryRegion::new(obstacle_addr, PAGE_SIZE),
             kind: VMAreaKind::Anon,
             permissions: VMAPermissions::ro(),
+            name: String::new(),
         };
         vm.mm.insert_and_merge(obstacle_vma);
         assert_eq!(vm.mm.vma_count(), 2);

--- a/src/drivers/fs/proc/task/mod.rs
+++ b/src/drivers/fs/proc/task/mod.rs
@@ -126,12 +126,18 @@ impl Inode for ProcTaskInode {
             FileType::Directory,
             7,
         ));
+        entries.push(Dirent::new(
+            "maps".to_string(),
+            InodeId::from_fsid_and_inodeid(PROCFS_ID, get_inode_id(&[&initial_str, "maps"])),
+            FileType::File,
+            8,
+        ));
         if self.desc.tid().value() == self.desc.tgid().value() && !self.is_task_dir {
             entries.push(Dirent::new(
                 "task".to_string(),
                 InodeId::from_fsid_and_inodeid(PROCFS_ID, get_inode_id(&[&initial_str, "task"])),
                 FileType::Directory,
-                8,
+                9,
             ));
         }
 


### PR DESCRIPTION
Implement the `maps` file which shows a process's VMA entries. Example
output:

```
[root@moss-machine /]# cat /proc/1/maps
500000000000-500000117000 r-xp 0000000000                    /bin/bash
50000012b000-500000130000 r--p 000011b000                    /bin/bash
500000130000-50000013e000 rw-p 0000120000                    /bin/bash
700000000000-70000002b000 r-xp 0000000000                    /lib/ld-linux-aarch64.so.1
70000003e000-700000040000 r--p 000002e000                    /lib/ld-linux-aarch64.so.1
700000040000-700000042000 rw-p 0000030000                    /lib/ld-linux-aarch64.so.1
7fffff510000-7fffff585000 r-xp 0000000000                    /usr/lib/libncursesw.so.6
7fffff585000-7fffff59b000 ---p 0000075000                    /usr/lib/libncursesw.so.6
7fffff59b000-7fffff5a0000 r--p 000007b000                    /usr/lib/libncursesw.so.6
7fffff5a0000-7fffff5a1000 rw-p 0000080000                    /usr/lib/libncursesw.so.6
7fffff5b0000-7fffff760000 r-xp 0000000000                    /usr/lib/libc.so.6
7fffff760000-7fffff76d000 ---p 00001b0000                    /usr/lib/libc.so.6
7fffff76d000-7fffff770000 r--p 00001bd000                    /usr/lib/libc.so.6
7fffff770000-7fffff772000 rw-p 00001c0000                    /usr/lib/libc.so.6
7fffff772000-7fffff779000 rw-p 0000000000
7fffff780000-7fffff7d9000 r-xp 0000000000                    /usr/lib/libreadline.so.8
7fffff7d9000-7fffff7ed000 ---p 0000059000                    /usr/lib/libreadline.so.8
7fffff7ed000-7fffff7f0000 r--p 000005d000                    /usr/lib/libreadline.so.8
7fffff7f0000-7fffff7f6000 rw-p 0000060000                    /usr/lib/libreadline.so.8
7fffff7f6000-7fffff7fb000 rw-p 0000000000
7fffff800000-800000063000 rw-p 0000000000                    [stack]
```
