### PR TITLE
Syscall fixups

### DIFF
--- a/src/fs/syscalls/at/statx.rs
+++ b/src/fs/syscalls/at/statx.rs
@@ -70,7 +70,7 @@ pub struct StatX {
     pub stx_btime: StatXTimestamp, // Creation time
     pub stx_ctime: StatXTimestamp, // Change time
     pub stx_mtime: StatXTimestamp, // Modification time
-    pub stx_mnt_id: u64,                    // Mount ID
+    pub stx_mnt_id: u64,           // Mount ID
 
     // Currently not supported on any current filesystems
     pub stx_rdev_major: u32,                // Device major ID

--- a/src/kernel/power.rs
+++ b/src/kernel/power.rs
@@ -1,5 +1,5 @@
-use core::sync::atomic::AtomicBool;
 use crate::{ArchImpl, arch::Arch, sched::current::current_task_shared};
+use core::sync::atomic::AtomicBool;
 use libkernel::{
     error::{KernelError, Result},
     proc::caps::CapabilitiesFlags,


### PR DESCRIPTION
- MNT_ID for statx (needed for systemd)
- CAD for reboot (needed for busybox init)
