### PR TITLE
Enable clippy lints for libkernel that were only enabled for moss

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 members = ["libkernel", "usertest"]
 
+[workspace.lints.clippy]
+semicolon_if_nothing_returned = "warn"
+uninlined_format_args = "warn"
+
 [package]
 name = "moss"
 version = "0.1.0"
@@ -32,3 +36,6 @@ smp = []
 strip = true
 opt-level = "z"
 codegen-units = 1
+
+[lints]
+workspace = true

--- a/libkernel/Cargo.toml
+++ b/libkernel/Cargo.toml
@@ -18,3 +18,6 @@ intrusive-collections = { version = "0.9.7", default-features = false }
 [dev-dependencies]
 rand = "0.9.1"
 tokio = { version = "1.47.1", features = ["full"] }
+
+[lints]
+workspace = true

--- a/libkernel/src/arch/arm64/memory/pg_tables.rs
+++ b/libkernel/src/arch/arm64/memory/pg_tables.rs
@@ -323,19 +323,19 @@ where
     PM: PageTableMapper,
 {
     if attrs.phys.size() != attrs.virt.size() {
-        Err(MapError::SizeMismatch)?
+        Err(MapError::SizeMismatch)?;
     }
 
     if attrs.phys.size() < PAGE_SIZE {
-        Err(MapError::TooSmall)?
+        Err(MapError::TooSmall)?;
     }
 
     if !attrs.phys.is_page_aligned() {
-        Err(MapError::PhysNotAligned)?
+        Err(MapError::PhysNotAligned)?;
     }
 
     if !attrs.virt.is_page_aligned() {
-        Err(MapError::VirtNotAligned)?
+        Err(MapError::VirtNotAligned)?;
     }
 
     while attrs.virt.size() > 0 {
@@ -442,7 +442,7 @@ where
 
         // Zero out the new table before use.
         ctx.mapper.with_page_table(new_pa, |new_pgtable| {
-            core::ptr::write_bytes(new_pgtable.as_ptr_mut() as *mut _ as *mut u8, 0, PAGE_SIZE)
+            core::ptr::write_bytes(new_pgtable.as_ptr_mut() as *mut _ as *mut u8, 0, PAGE_SIZE);
         })?;
 
         // Set the descriptor at the current level to point to the new table.

--- a/libkernel/src/arch/arm64/memory/pg_tear_down.rs
+++ b/libkernel/src/arch/arm64/memory/pg_tear_down.rs
@@ -96,7 +96,7 @@ impl RecursiveTeardownWalker for L3Table {
                         deallocator(addr);
                     }
                 }
-            })?
+            })?;
         }
 
         Ok(())

--- a/libkernel/src/arch/arm64/memory/pg_walk.rs
+++ b/libkernel/src/arch/arm64/memory/pg_walk.rs
@@ -71,7 +71,7 @@ where
 
                 T::NextLevel::walk(next_desc.cast(), sub_region, ctx, modifier)?;
             } else if desc.is_valid() {
-                Err(MapError::NotL3Mapped)?
+                Err(MapError::NotL3Mapped)?;
             } else {
                 // Permit sparse mappings.
                 continue;

--- a/libkernel/src/fs/filesystems/ext4/mod.rs
+++ b/libkernel/src/fs/filesystems/ext4/mod.rs
@@ -63,7 +63,7 @@ impl From<ext4_view::Ext4Error> for KernelError {
             ext4_view::Ext4Error::NotADirectory => KernelError::Fs(FsError::NotADirectory),
             ext4_view::Ext4Error::Corrupt(_) => KernelError::Fs(FsError::InvalidFs),
             e => {
-                error!("Unmapped EXT4 error: {:?}", e);
+                error!("Unmapped EXT4 error: {e:?}");
                 KernelError::Other("EXT4 error")
             }
         }

--- a/libkernel/src/fs/filesystems/fat32/bpb.rs
+++ b/libkernel/src/fs/filesystems/fat32/bpb.rs
@@ -65,8 +65,7 @@ impl BiosParameterBlock {
             512 | 1024 | 2048 | 4096 => {} // Good!
             _ => {
                 warn!(
-                    "Bytes per sector {} is not a valid value (must be 512, 1024, 2048, or 4096).",
-                    bytes_per_sector
+                    "Bytes per sector {bytes_per_sector} is not a valid value (must be 512, 1024, 2048, or 4096)."
                 );
                 return Err(FsError::InvalidFs.into());
             }
@@ -75,10 +74,7 @@ impl BiosParameterBlock {
         if !bpb.bytes_per_sector.is_power_of_two() {
             let bytes_per_sector = bpb.bytes_per_sector;
 
-            warn!(
-                "Bytes per sector 0x{:X} not a power of two.",
-                bytes_per_sector
-            );
+            warn!("Bytes per sector 0x{bytes_per_sector:X} not a power of two.",);
             return Err(FsError::InvalidFs.into());
         }
 
@@ -93,7 +89,7 @@ impl BiosParameterBlock {
         if !bpb.root_cluster.is_valid() {
             let root_cluster = bpb.root_cluster;
 
-            warn!("Root cluster {} < 2.", root_cluster);
+            warn!("Root cluster {root_cluster} < 2.");
 
             return Err(FsError::InvalidFs.into());
         }

--- a/libkernel/src/memory/allocators/slab/slab.rs
+++ b/libkernel/src/memory/allocators/slab/slab.rs
@@ -51,7 +51,7 @@ impl Slab {
                         u16::MAX
                     } else {
                         (i + 1) as u16
-                    })
+                    });
             }
         }
 

--- a/libkernel/src/memory/kbuf.rs
+++ b/libkernel/src/memory/kbuf.rs
@@ -64,7 +64,7 @@ impl<T, S: Storage<Item = T>, C: CpuOps> KBufCore<T, S, C> {
             |inner| &mut inner.write_waiters,
             |inner| if inner.buf.is_full() { None } else { Some(()) },
         )
-        .await
+        .await;
     }
 
     /// Pushes a value of type `T` into the buffer. If the buffer is full, this

--- a/libkernel/src/memory/permissions.rs
+++ b/libkernel/src/memory/permissions.rs
@@ -200,7 +200,7 @@ impl fmt::Display for PtePermissions {
             '-'
         };
 
-        write!(f, "{}{}{} {}", r, w_or_c, x, user)
+        write!(f, "{r}{w_or_c}{x} {user}")
     }
 }
 

--- a/libkernel/src/sync/mpsc.rs
+++ b/libkernel/src/sync/mpsc.rs
@@ -66,7 +66,7 @@ impl<T: Send, C: CpuOps> Drop for Reciever<T, C> {
             state.recv_gone = true;
 
             WakeupType::None
-        })
+        });
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,6 @@
 #![feature(used_with_arg)]
 #![feature(likely_unlikely)]
 #![feature(box_as_ptr)]
-#![warn(clippy::semicolon_if_nothing_returned)]
-#![warn(clippy::uninlined_format_args)]
 
 use alloc::{
     boxed::Box,


### PR DESCRIPTION
I think it makes sense to enable them for libkernel as well.