### PR TITLE
libkernel/slab: fix UB and accounting bugs identified by Miri

### DIFF
--- a/libkernel/src/memory/allocators/frame.rs
+++ b/libkernel/src/memory/allocators/frame.rs
@@ -37,7 +37,8 @@ pub enum FrameState {
 #[derive(Debug, Clone)]
 pub struct Frame {
     pub state: FrameState,
-    pub link: LinkedListLink, // only used in free nodes.
+    // used in free nodes list (FA), Free and Partial Lists (SA).
+    pub link: LinkedListLink,
     pub pfn: PageFrame,
 }
 


### PR DESCRIPTION
Fix several issues in the slab allocator identified by the heap stress
tests (intermittent) and running the tests under Miri.

1. Fix Undefined Behavior. Previously, the allocator created temporary
   `&mut Frame` references while raw pointers to that frame existed in the
   intrusive `partial` or `free` lists. Under Miri's strict aliasing rules,
   creating a unique reference to the whole struct invalidated the list
   pointers.

   The fix implements "split borrowing": we now maintain raw pointers to
   the frame and only create mutable references to the `.state` field
   when needed, ensuring the `.link` field remains valid for the
   intrusive list.

2. Fix `free_list_sz` accounting. In `try_alloc`, the `free_list_sz`
   counter was not being decremented when a slab was successfully popped
   from the free list. This caused the allocator to believe it had free
   slabs when the list was actually empty, leading to panics during
   batch-free operations.

3. Increase heap stress tests. The test suite now runs the stress test
   in a loop to catch state persistence bugs and ensures the allocator is
   fully torn down and reset between iterations.

Fixes: #220