### PR TITLE
Fix issues for systemd bringup

### DIFF
--- a/libkernel/src/error/syscall_error.rs
+++ b/libkernel/src/error/syscall_error.rs
@@ -38,6 +38,7 @@ pub const EDOM: isize = -33;
 pub const ERANGE: isize = -34;
 pub const EWOULDBLOCK: isize = -EAGAIN;
 pub const ENOSYS: isize = -38;
+pub const EAFNOSUPPORT: isize = -97;
 pub const EOPNOTSUPP: isize = -95;
 pub const ETIMEDOUT: isize = -110;
 
@@ -63,6 +64,7 @@ pub fn kern_err_to_syscall(err: KernelError) -> isize {
         KernelError::OpNotSupported => EOPNOTSUPP,
         KernelError::Interrupted => EINTR,
         KernelError::NoProcess => ESRCH,
+        KernelError::AddressFamilyNotSupported => EAFNOSUPPORT,
         e => todo!("{e}"),
     }
 }

--- a/src/arch/arm64/exceptions/syscall.rs
+++ b/src/arch/arm64/exceptions/syscall.rs
@@ -224,6 +224,7 @@ pub async fn handle_syscall(mut ctx: ProcessCtx) {
         0x19 => sys_fcntl(&ctx, arg1.into(), arg2 as _, arg3 as _).await,
         0x1d => sys_ioctl(&ctx, arg1.into(), arg2 as _, arg3 as _).await,
         0x20 => Ok(0), // sys_flock is a noop
+        0x21 => Err(KernelError::NotSupported),
         0x22 => sys_mkdirat(&ctx, arg1.into(), TUA::from_value(arg2 as _), arg3 as _).await,
         0x23 => sys_unlinkat(&ctx, arg1.into(), TUA::from_value(arg2 as _), arg3 as _).await,
         0x24 => {
@@ -753,6 +754,7 @@ pub async fn handle_syscall(mut ctx: ProcessCtx) {
             .await
         }
         0x125 => Err(KernelError::NotSupported),
+        0x1ae => Err(KernelError::NotSupported),
         0x1b4 => sys_close_range(&ctx, arg1.into(), arg2.into(), arg3 as _).await,
         0x1b7 => {
             sys_faccessat2(

--- a/src/drivers/fs/dev.rs
+++ b/src/drivers/fs/dev.rs
@@ -25,6 +25,17 @@ pub struct DevFs {
 
 impl DevFs {
     pub fn new() -> Arc<Self> {
+        let shm = DevFsINode {
+            id: InodeId::from_fsid_and_inodeid(DEVFS_ID, 1),
+            attr: SpinLock::new(FileAttr {
+                file_type: FileType::Directory,
+                permissions: FilePermissions::from_bits_retain(0o755),
+                ..FileAttr::default()
+            }),
+            kind: InodeKind::Directory(SpinLock::new(BTreeMap::new())),
+        };
+        let mut root_children = BTreeMap::new();
+        root_children.insert("shm".to_string(), Arc::new(shm));
         let root_inode = Arc::new(DevFsINode {
             id: InodeId::from_fsid_and_inodeid(DEVFS_ID, 0),
             attr: SpinLock::new(FileAttr {
@@ -32,12 +43,12 @@ impl DevFs {
                 permissions: FilePermissions::from_bits_retain(0o755),
                 ..FileAttr::default()
             }),
-            kind: InodeKind::Directory(SpinLock::new(BTreeMap::new())),
+            kind: InodeKind::Directory(SpinLock::new(root_children)),
         });
 
         Arc::new(Self {
             root: root_inode,
-            next_inode_id: AtomicU64::new(1),
+            next_inode_id: AtomicU64::new(2),
         })
     }
 

--- a/src/kernel/hostname.rs
+++ b/src/kernel/hostname.rs
@@ -1,4 +1,4 @@
-use crate::memory::uaccess::cstr::UserCStr;
+use crate::memory::uaccess::copy_from_user_slice;
 use crate::sched::syscall_ctx::ProcessCtx;
 use crate::sync::OnceLock;
 use crate::sync::SpinLock;
@@ -33,9 +33,10 @@ pub async fn sys_sethostname(
         return Err(KernelError::NameTooLong);
     }
     let mut buf = vec![0u8; name_len];
-    let name = UserCStr::from_ptr(name_ptr)
-        .copy_from_user(&mut buf)
-        .await?;
+    copy_from_user_slice(name_ptr.to_untyped(), &mut buf).await?;
+    let name = core::str::from_utf8(&buf)
+        .map_err(|_| KernelError::InvalidValue)?
+        .trim_end_matches('\0');
     *hostname().lock_save_irq() = name.to_string();
     Ok(0)
 }


### PR DESCRIPTION
- Map `AddressFamilyNotSupported` properly
- `mknodat` and `fsopen` are marked as unsupported
- `/dev/shm/` exists for tmpfs mounting
- Fix error with sethostname using a byte string instead of a null terminated cstr.