### PR TITLE
libkernel: address: add virtualisation guest types

### DIFF
--- a/libkernel/src/memory/address.rs
+++ b/libkernel/src/memory/address.rs
@@ -57,16 +57,22 @@ pub struct Virtual;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Physical;
 
+/// Marker for a physical guest memory address type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct GuestPhysical;
+
 /// Marker for user memory address type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct User;
 
 impl sealed::Sealed for Virtual {}
 impl sealed::Sealed for Physical {}
+impl sealed::Sealed for GuestPhysical {}
 impl sealed::Sealed for User {}
 
 impl MemKind for Virtual {}
 impl MemKind for Physical {}
+impl MemKind for GuestPhysical {}
 impl MemKind for User {}
 
 /// A memory address with a kind (`Virtual`, `Physical`, or `User`) and an
@@ -189,6 +195,10 @@ pub type TPA<T> = Address<Physical, T>;
 pub type TVA<T> = Address<Virtual, T>;
 /// A typed user address.
 pub type TUA<T> = Address<User, T>;
+/// A typed guest physical address.
+pub type TGPA<T> = Address<GuestPhysical, T>;
+/// A typed host physical address.
+pub type THPA<T> = TPA<T>;
 
 /// An untyped physical address.
 pub type PA = Address<Physical, ()>;
@@ -196,6 +206,10 @@ pub type PA = Address<Physical, ()>;
 pub type VA = Address<Virtual, ()>;
 /// An untyped user address.
 pub type UA = Address<User, ()>;
+/// An untyped guest physical address.
+pub type GPA = Address<GuestPhysical, ()>;
+/// An untyped host physical address.
+pub type HPA = PA;
 
 impl<T> TPA<T> {
     /// Convert to a raw const pointer.

--- a/libkernel/src/memory/region.rs
+++ b/libkernel/src/memory/region.rs
@@ -31,7 +31,7 @@
 
 use super::{
     PAGE_SHIFT, PAGE_SIZE,
-    address::{Address, AddressTranslator, MemKind, Physical, User, Virtual},
+    address::{Address, AddressTranslator, GuestPhysical, MemKind, Physical, User, Virtual},
     page::PageFrame,
 };
 
@@ -251,8 +251,7 @@ impl<T: MemKind> MemoryRegion<T> {
     }
 
     /// Increases the capacity of the region by size bytes.
-    #[cfg(feature = "proc_vm")]
-    pub(crate) fn expand_by(&mut self, size: usize) {
+    pub fn expand_by(&mut self, size: usize) {
         assert!(size & crate::memory::PAGE_MASK == 0);
 
         self.size += size;
@@ -413,6 +412,9 @@ impl VirtMemoryRegion {
 
 /// A memory region of user-space addresses.
 pub type UserMemoryRegion = MemoryRegion<User>;
+
+/// A memory region of guest-physical memory.
+pub type GuestPhysMemoryRegion = MemoryRegion<GuestPhysical>;
 
 /// A representation of a `MemoryRegion` that has been expanded to be page-aligned.
 ///


### PR DESCRIPTION
Add address types for use in virtualised environments.