### PR TITLE
Check for LLVM and Rust objcopy binaries before throwing

### DIFF
--- a/scripts/qemu_runner.py
+++ b/scripts/qemu_runner.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python3
 
 import argparse
+import shutil
 import subprocess
+
+def find_objcopy():
+    for candidate in ["aarch64-none-elf-objcopy", "llvm-objcopy", "rust-objcopy"]:
+        if shutil.which(candidate):
+            return candidate
+    raise FileNotFoundError("No objcopy found. Install gcc-aarch64-embedded or llvm.")
 
 parser = argparse.ArgumentParser(description="QEMU runner")
 
@@ -23,7 +30,7 @@ args = parser.parse_args()
 elf_executable = args.elf_executable
 bin_executable_location = elf_executable.replace(".elf", "") + ".bin"
 # Convert the ELF executable to a binary format
-subprocess.run(["aarch64-none-elf-objcopy", "-O", "binary", elf_executable, bin_executable_location], check=True)
+subprocess.run([find_objcopy(), "-O", "binary", elf_executable, bin_executable_location], check=True)
 
 append_args = ""
 


### PR DESCRIPTION
The `qemu_runner.py` file hardcoded `aarch64-none-elf-objcopy` for the `objcopy` binary, which is distributed as part of the Arm GNU toolchain, and isn't available by default on macOS. LLVM ships with its own objcopy binary that has support for multiple targets and is described as a "drop-in replacement for GNU's objcopy" (see: https://llvm.org/docs/CommandGuide/llvm-objcopy.html).
The `qemu_runner.py` now checks if the system has `llvm-objcopy` and `rust-objcopy` (cargo wrapper over `llvm-objcopy`) and invokes whichever one it finds. If it doesn't find any, it throws an error instructing the programmer to install any of the above objcopy binaries.