### PR TITLE
Fix flake.nix toolchain hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         pkgs = import nixpkgs { inherit system; };
         toolchain = fenix.packages.${system}.fromToolchainFile {
           file = ./rust-toolchain.toml;
-          sha256 = "sha256-ggvRZZFjlAlrZVjqul/f/UpU5CEhDbdKZU0OCR8Uzbc=";
+          sha256 = "sha256-gIs/sWVA0osI/I+duBKhKaExKdVBPNswYHoS7H+gljI=";
         };
         shell = pkgs.mkShell {
           buildInputs = with pkgs; [


### PR DESCRIPTION
Updated sha256 for `fromToolchainFile` to the correct value so `builds/devShell` can be generated successfully.